### PR TITLE
Implicit limit to file size of uploaded CSV

### DIFF
--- a/app/front/scripts/config/env.js
+++ b/app/front/scripts/config/env.js
@@ -20,7 +20,8 @@
       key: 'default'
     },
     steps: services.data.steps,
-    isWizard: window.isWizard
+    isWizard: window.isWizard,
+    maxFileSizeToStore: 100 * 1024 * 1024 // 100Mb
   };
 
   angular.module('Application')

--- a/app/front/scripts/controllers/upload-file.js
+++ b/app/front/scripts/controllers/upload-file.js
@@ -2,8 +2,13 @@
 
   angular.module('Application')
     .controller('UploadFileController', [
-      '$scope', '_', 'UploadFileService', 'ApplicationLoader',
-      function($scope, _, UploadFileService, ApplicationLoader) {
+      '$scope', '_', 'UploadFileService', 'ApplicationLoader', 'LoginService',
+      'Configuration',
+      function($scope, _, UploadFileService, ApplicationLoader, LoginService,
+        Configuration) {
+        $scope.login = LoginService;
+        $scope.maxFileSizeToStore = Configuration.maxFileSizeToStore;
+
         ApplicationLoader.then(function() {
 
           function reloadState() {

--- a/app/front/scripts/services/storage.js
+++ b/app/front/scripts/services/storage.js
@@ -100,7 +100,17 @@
             }).then(function() {}); // Force execute
           },
           saveApplicationState: function() {
-            var state = deepCloneValue(prepareValueForSaving(ApplicationState));
+            var state = ApplicationState;
+
+            // Check file size. If file is too large, do not store state
+            if (state.uploadFile && state.uploadFile.file) {
+              var size = state.uploadFile.file.size;
+              if (size > Configuration.maxFileSizeToStore) {
+                state = null;
+              }
+            }
+
+            state = deepCloneValue(prepareValueForSaving(state));
             return result.set(Configuration.storage.key, state);
           },
           clearApplicationState: function() {

--- a/app/front/scripts/services/upload-file.js
+++ b/app/front/scripts/services/upload-file.js
@@ -4,10 +4,8 @@
     .factory('UploadFileService', [
       '_', 'PackageService', 'ValidationService', 'Configuration',
       'UtilsService', 'Services', 'ApplicationState', 'ApplicationLoader',
-      'StepsService',
       function(_, PackageService, ValidationService, Configuration,
-        UtilsService, Services, ApplicationState, ApplicationLoader,
-        StepsService) {
+        UtilsService, Services, ApplicationState, ApplicationLoader) {
         var utils = Services.utils;
 
         var result = {};

--- a/app/front/scripts/services/validation.js
+++ b/app/front/scripts/services/validation.js
@@ -65,7 +65,7 @@
             return !_.contains(requiredConcepts, false);
           },
           validateAttributesForm: function(form) {
-            if (!form) {
+            if (!form || !form.$dirty) {
               return;
             }
             if (!form.$valid) {

--- a/app/services/utils.js
+++ b/app/services/utils.js
@@ -535,9 +535,13 @@ module.exports.getDataForPreview = function(resources, maxCount) {
   });
 };
 
-module.exports.blobToFileDescriptor = function(blob) {
+module.exports.blobToFileDescriptor = function(blob, maxAllowedSize) {
   if ((typeof Blob == 'undefined') || !_.isFunction(Blob) ||
     !(blob instanceof Blob)) {
+    return Promise.resolve(blob);
+  }
+  if (!!maxAllowedSize && (maxAllowedSize > 0) &&
+    (blob.size > maxAllowedSize)) {
     return Promise.resolve(blob);
   }
   return new Promise(function(resolve, reject) {
@@ -560,11 +564,15 @@ module.exports.blobToFileDescriptor = function(blob) {
 module.exports.fileDescriptorToBlob = function(descriptor) {
   var result = descriptor;
   if (_.isObject(descriptor) && _.isFunction(Blob)) {
-    result = new Blob([descriptor.data], {
-      type: descriptor.type
-    });
-    result.name = descriptor.name;
-    result.encoding = descriptor.encoding;
+    if (descriptor instanceof Blob) {
+      result = descriptor;
+    } else {
+      result = new Blob([descriptor.data], {
+        type: descriptor.type
+      });
+      result.name = descriptor.name;
+      result.encoding = descriptor.encoding;
+    }
   }
   return Promise.resolve(result);
 };

--- a/app/views/partials/steps/upload-file.html
+++ b/app/views/partials/steps/upload-file.html
@@ -1,5 +1,18 @@
 {% raw %}
 <section id="step1-wrapper">
+  <div ng-if="state.isFile && (state.file.size > maxFileSizeToStore)">
+    <div class="alert alert-warning">
+      <i class="fa fa-2x fa-exclamation-circle vertical-align-middle margin-right-4"></i>
+      Uploaded file is very large, so it will not be stored in memory. This means that
+      you may lose progress if you reload this page.
+    </div>
+    <div ng-if="!login.isLoggedIn" class="alert alert-warning">
+      <i class="fa fa-2x fa-exclamation-circle vertical-align-middle margin-right-4"></i>
+      You are not logged in. Please <a href="javascript:void(0)" ng-click="login.login()">login now</a>
+      if you would like to publish your dataset using this wizard.
+    </div>
+  </div>
+
   <div class="row form-group">
     <div ng-hide="isUrlSelected" ng-class="{'col-sm-5': !isUrlSelected && !isFileSelected, 'col-xs-12': isFileSelected}">
       <div class="input-group">


### PR DESCRIPTION
If user selects file from local hard drive, and size of that file is too large (current limit is 100Mb), then do not store app state (we cannot only discard file and keep data from other steps because it leads to inconsistent application state). Instead show warnings on first step: 1st one notifies user that app state will be lost on page reload, and 2nd (only when user is not logged in) - asks user to log in before continue. 2nd warning complements 1st - because login process causes page reload, so ask user to log in first, and only then continue working.
