### PR TITLE
[#1309] Respect X-Forwarded-* headers

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -14,6 +14,8 @@ module.exports.start = function() {
   return new Promise(function(resolve, reject) {
     var app = express();
 
+    app.set('trust proxy', true);
+
     app.set('config', config);
     app.set('port', config.get('app:port'));
     app.set('views', path.join(__dirname, '/views'));


### PR DESCRIPTION
Specially `X-Forwarded-proto`, which controls the protocol used on redirects.
We need to redirect to the same protocol used by our proxy (HTTPS), regardless
if we are ourselves running HTTP or HTTPS.

openspending/openspending#1309